### PR TITLE
use require_relative to allow vendoring in the source files

### DIFF
--- a/lib/fluent/plugin/parser_viaq_docker_audit.rb
+++ b/lib/fluent/plugin/parser_viaq_docker_audit.rb
@@ -1,6 +1,7 @@
-require "fluent/plugin/viaq_docker_audit"
 require 'fluent/parser'
 require 'fluent/time'
+
+require_relative 'viaq_docker_audit'
 
 module Fluent
   class ViaqDockerAuditParser < Parser


### PR DESCRIPTION
use require_relative to allow vendoring in the source files